### PR TITLE
Reduce max width on individual blogs page

### DIFF
--- a/components/blogs/Author.tsx
+++ b/components/blogs/Author.tsx
@@ -1,26 +1,24 @@
-import React from 'react';
-import { PostQueryResult } from '@/@types/cms';
-import { useTranslations } from 'next-intl';
-import TeamMemberCard from '../cards/TeamMember';
+import React from "react";
+import { PostQueryResult } from "@/@types/cms";
+import { useTranslations } from "next-intl";
+import TeamMemberCard from "../cards/TeamMember";
 
-interface Props extends React.ComponentProps<'section'> {
-	post: NonNullable<PostQueryResult>;
-	locale: LocaleLanguages;
+interface Props extends React.ComponentProps<"section"> {
+  post: NonNullable<PostQueryResult>;
+  locale: LocaleLanguages;
 }
 
 const BlogAuthor: React.FC<Props> = ({ post }) => {
-	const t = useTranslations('pages.blogs.author');
-	return (
-		<section className='max-w-5xl mx-auto w-full p-4 mt-8'>
-			<h2 className='text-2xl font-heading font-medium'>
-				{t('heading')}
-			</h2>
-			<hr className='border-b-4 max-w-[10rem] border-b-primary-clinic rounded-lg mt-2' />
-			<div className='max-w-md mt-8'>
-				<TeamMemberCard member={post?.author!} />
-			</div>
-		</section>
-	);
+  const t = useTranslations("pages.blogs.author");
+  return (
+    <section className="max-w-3xl mx-auto w-full p-4 mt-8">
+      <h2 className="text-2xl font-heading font-medium">{t("heading")}</h2>
+      <hr className="border-b-4 max-w-[10rem] border-b-primary-clinic rounded-lg mt-2" />
+      <div className="max-w-md mt-8">
+        <TeamMemberCard member={post?.author!} />
+      </div>
+    </section>
+  );
 };
 
 export default BlogAuthor;

--- a/components/blogs/Categories.tsx
+++ b/components/blogs/Categories.tsx
@@ -22,7 +22,7 @@ const BlogCategories: React.FC<Props> = ({ post, locale }) => {
       <hr className="border-b-4 max-w-[10rem] border-b-primary-clinic rounded-lg mt-2" />
       <div className="flex flex-wrap gap-4 mt-8">
         {post?.categories?.map((category) => (
-          <Tooltip key={post._id}>
+          <Tooltip key={category._id}>
             <TooltipTrigger className="cursor-pointer">
               <Badge className="flex items-center gap-1">
                 <InfoIcon size={16} />

--- a/components/blogs/Categories.tsx
+++ b/components/blogs/Categories.tsx
@@ -1,44 +1,42 @@
-import React from 'react';
-import { useTranslations } from 'next-intl';
-import { PostQueryResult } from '@/@types/cms';
-import { Badge } from '@/components/ui/badge';
+import React from "react";
+import { useTranslations } from "next-intl";
+import { PostQueryResult } from "@/@types/cms";
+import { Badge } from "@/components/ui/badge";
 import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { InfoIcon } from 'lucide-react';
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { InfoIcon } from "lucide-react";
 
-interface Props extends React.ComponentProps<'section'> {
-	post: PostQueryResult;
-	locale: LocaleLanguages;
+interface Props extends React.ComponentProps<"section"> {
+  post: PostQueryResult;
+  locale: LocaleLanguages;
 }
 
 const BlogCategories: React.FC<Props> = ({ post, locale }) => {
-	const t = useTranslations('pages.blogs.categories');
-	return (
-		<section className='max-w-5xl mx-auto w-full p-4 mt-8'>
-			<h2 className='text-2xl font-heading font-medium'>
-				{t('heading')}
-			</h2>
-			<hr className='border-b-4 max-w-[10rem] border-b-primary-clinic rounded-lg mt-2' />
-			<div className='flex flex-wrap gap-4 mt-8'>
-				{post?.categories?.map((category) => (
-					<Tooltip key={post._id}>
-						<TooltipTrigger className='cursor-pointer'>
-							<Badge className='flex items-center gap-1'>
-								<InfoIcon size={16} />
-								<span>{category?.title?.[locale]}</span>
-							</Badge>
-						</TooltipTrigger>
-						<TooltipContent className='max-w-xs'>
-							{category?.description?.[locale]}
-						</TooltipContent>
-					</Tooltip>
-				))}
-			</div>
-		</section>
-	);
+  const t = useTranslations("pages.blogs.categories");
+  return (
+    <section className="max-w-3xl mx-auto w-full p-4 mt-8">
+      <h2 className="text-2xl font-heading font-medium">{t("heading")}</h2>
+      <hr className="border-b-4 max-w-[10rem] border-b-primary-clinic rounded-lg mt-2" />
+      <div className="flex flex-wrap gap-4 mt-8">
+        {post?.categories?.map((category) => (
+          <Tooltip key={post._id}>
+            <TooltipTrigger className="cursor-pointer">
+              <Badge className="flex items-center gap-1">
+                <InfoIcon size={16} />
+                <span>{category?.title?.[locale]}</span>
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              {category?.description?.[locale]}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </section>
+  );
 };
 
 export default BlogCategories;

--- a/components/blogs/Content.tsx
+++ b/components/blogs/Content.tsx
@@ -1,24 +1,21 @@
-import React from 'react';
-import { PostQueryResult } from '@/@types/cms';
-import { PortableText } from '@portabletext/react';
-import { ptComponents } from '@/sanity/lib/ptComponents';
+import React from "react";
+import { PostQueryResult } from "@/@types/cms";
+import { PortableText } from "@portabletext/react";
+import { ptComponents } from "@/sanity/lib/ptComponents";
 
-interface Props extends React.ComponentProps<'section'> {
-	post: NonNullable<PostQueryResult>;
-	locale: LocaleLanguages;
+interface Props extends React.ComponentProps<"section"> {
+  post: NonNullable<PostQueryResult>;
+  locale: LocaleLanguages;
 }
 
 const BlogContent: React.FC<Props> = ({ post, locale }) => {
-	return (
-		<section className='max-w-5xl mx-auto w-full p-4 mt-8 prose'>
-			{post?.body?.[locale] && (
-				<PortableText
-					value={post.body?.[locale]}
-					components={ptComponents}
-				/>
-			)}
-		</section>
-	);
+  return (
+    <section className="max-w-3xl mx-auto w-full p-4 mt-8 prose">
+      {post?.body?.[locale] && (
+        <PortableText value={post.body?.[locale]} components={ptComponents} />
+      )}
+    </section>
+  );
 };
 
 export default BlogContent;

--- a/components/blogs/Header.tsx
+++ b/components/blogs/Header.tsx
@@ -1,43 +1,41 @@
-import type React from 'react';
-import type { PostQueryResult } from '@/@types/cms';
-import Image from 'next/image';
-import { urlForImage } from '@/sanity/lib/image';
+import type React from "react";
+import type { PostQueryResult } from "@/@types/cms";
+import Image from "next/image";
+import { urlForImage } from "@/sanity/lib/image";
 
-interface Props extends React.ComponentProps<'header'> {
-	post: NonNullable<PostQueryResult>;
-	locale: LocaleLanguages;
+interface Props extends React.ComponentProps<"header"> {
+  post: NonNullable<PostQueryResult>;
+  locale: LocaleLanguages;
 }
 
 const BlogHeader: React.FC<Props> = ({ post, locale }) => {
-	return (
-		<header className='max-w-5xl mx-auto w-full p-4 mt-8'>
-			<section className='flex flex-col lg:flex-row lg:gap-6 gap-4'>
-				<div className='overflow-hidden rounded-lg lg:w-2/3'>
-					<Image
-						src={
-							(post.thumbnail &&
-								urlForImage(post.thumbnail)
-									.format('webp')
-									.url()) ??
-							''
-						}
-						alt={post?.thumbnail?.alt ?? post.title?.[locale] ?? ''}
-						width={500}
-						height={500}
-						className='w-full h-auto aspect-video object-cover object-center'
-					/>
-				</div>
-				<div className='lg:w-1/3 flex flex-col justify-center gap-4'>
-					<h1 className='font-heading font-medium text-2xl lg:text-4xl lg:text-left text-center'>
-						{post?.title?.[locale]}
-					</h1>
-					<p className='text-lg lg:text-xl text-justify text-slate-500'>
-						{post?.description?.[locale]}
-					</p>
-				</div>
-			</section>
-		</header>
-	);
+  return (
+    <header className="max-w-3xl mx-auto w-full p-4 mt-8">
+      <section className="flex flex-col lg:flex-row lg:gap-6 gap-4">
+        <div className="overflow-hidden rounded-lg lg:w-2/3">
+          <Image
+            src={
+              (post.thumbnail &&
+                urlForImage(post.thumbnail).format("webp").url()) ??
+              ""
+            }
+            alt={post?.thumbnail?.alt ?? post.title?.[locale] ?? ""}
+            width={500}
+            height={500}
+            className="w-full h-auto aspect-video object-cover object-center"
+          />
+        </div>
+        <div className="lg:w-1/3 flex flex-col justify-center gap-4">
+          <h1 className="font-heading font-medium text-2xl lg:text-4xl lg:text-left text-center">
+            {post?.title?.[locale]}
+          </h1>
+          <p className="text-lg lg:text-xl text-justify text-slate-500">
+            {post?.description?.[locale]}
+          </p>
+        </div>
+      </section>
+    </header>
+  );
 };
 
 export default BlogHeader;

--- a/components/blogs/Header.tsx
+++ b/components/blogs/Header.tsx
@@ -11,8 +11,16 @@ interface Props extends React.ComponentProps<"header"> {
 const BlogHeader: React.FC<Props> = ({ post, locale }) => {
   return (
     <header className="max-w-3xl mx-auto w-full p-4 mt-8">
-      <section className="flex flex-col lg:flex-row lg:gap-6 gap-4">
-        <div className="overflow-hidden rounded-lg lg:w-2/3">
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-col justify-center gap-4">
+          <h1 className="font-heading font-medium text-2xl lg:text-4xl lg:text-left text-center">
+            {post?.title?.[locale]}
+          </h1>
+          <p className="text-lg lg:text-xl text-justify text-slate-500">
+            {post?.description?.[locale]}
+          </p>
+        </div>
+        <div className="overflow-hidden rounded-lg w-full">
           <Image
             src={
               (post.thumbnail &&
@@ -24,14 +32,6 @@ const BlogHeader: React.FC<Props> = ({ post, locale }) => {
             height={500}
             className="w-full h-auto aspect-video object-cover object-center"
           />
-        </div>
-        <div className="lg:w-1/3 flex flex-col justify-center gap-4">
-          <h1 className="font-heading font-medium text-2xl lg:text-4xl lg:text-left text-center">
-            {post?.title?.[locale]}
-          </h1>
-          <p className="text-lg lg:text-xl text-justify text-slate-500">
-            {post?.description?.[locale]}
-          </p>
         </div>
       </section>
     </header>

--- a/components/blogs/SocialShare.tsx
+++ b/components/blogs/SocialShare.tsx
@@ -1,23 +1,23 @@
 /* eslint-disable react/jsx-no-literals */
-'use client';
+"use client";
 
 // Dependencies
-import React from 'react';
-import { Button } from '@/components/ui/button';
-import { Copy } from 'lucide-react';
-import TwitterX from '../icons/TwitterX';
-import WhatsApp from '../icons/WhatsApp';
-import Reddit from '../icons/Reddit';
-import { LinkedinIcon } from 'lucide-react';
-import { PostQueryResult } from '@/@types/cms';
-import { useToast } from '@/components/ui/use-toast';
-import { WEBSITE_URL } from '@/constants/clinic';
-import { Link } from '@/lib/routing';
-import { useTranslations } from 'next-intl';
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Copy } from "lucide-react";
+import TwitterX from "../icons/TwitterX";
+import WhatsApp from "../icons/WhatsApp";
+import Reddit from "../icons/Reddit";
+import { LinkedinIcon } from "lucide-react";
+import { PostQueryResult } from "@/@types/cms";
+import { useToast } from "@/components/ui/use-toast";
+import { WEBSITE_URL } from "@/constants/clinic";
+import { Link } from "@/lib/routing";
+import { useTranslations } from "next-intl";
 
-type SocialShareProps = React.ComponentProps<'section'> & {
-	post: NonNullable<PostQueryResult>;
-	locale: LocaleLanguages;
+type SocialShareProps = React.ComponentProps<"section"> & {
+  post: NonNullable<PostQueryResult>;
+  locale: LocaleLanguages;
 };
 
 /**
@@ -26,78 +26,67 @@ type SocialShareProps = React.ComponentProps<'section'> & {
  * @returns {JSX.Element} The rendered social share section.
  */
 const SocialShare: React.FC<SocialShareProps> = ({ post, locale }) => {
-	const LINK = `${WEBSITE_URL}/${locale}/blogs/${post.slug?.current}`;
-	const SHARE_TEXT = encodeURI(post.title?.[locale] ?? '');
-	const SHARE_LINK = encodeURI(LINK);
+  const LINK = `${WEBSITE_URL}/${locale}/blogs/${post.slug?.current}`;
+  const SHARE_TEXT = encodeURI(post.title?.[locale] ?? "");
+  const SHARE_LINK = encodeURI(LINK);
 
-	const { toast } = useToast();
-	const t = useTranslations('pages.blogs.share');
+  const { toast } = useToast();
+  const t = useTranslations("pages.blogs.share");
 
-	const WHATSAPP_TEXT = encodeURI(`${post.title}\n\nRead here: ${LINK}`);
-	// const LINKEDIN_TEXT = encodeURI(`mini=true&url=${LINK}&title=${post.title}&summary=${WEBSITE_URL}&source=Sundar Clinic`)
+  const WHATSAPP_TEXT = encodeURI(`${post.title}\n\nRead here: ${LINK}`);
+  // const LINKEDIN_TEXT = encodeURI(`mini=true&url=${LINK}&title=${post.title}&summary=${WEBSITE_URL}&source=Sundar Clinic`)
 
-	const handleCopyLinkToClipboard = () => {
-		navigator.clipboard.writeText(LINK);
-		toast({
-			title: 'Link Copied!',
-			description: 'The link has been copied to your clipboard.',
-		});
-	};
+  const handleCopyLinkToClipboard = () => {
+    navigator.clipboard.writeText(LINK);
+    toast({
+      title: "Link Copied!",
+      description: "The link has been copied to your clipboard.",
+    });
+  };
 
-	return (
-		<section className='mt-8 max-w-5xl mx-auto w-full p-4'>
-			<h3 className='font-medium'>{t('heading')}</h3>
-			<div className='flex items-center gap-2 flex-wrap mt-2'>
-				<Button
-					className='bg-green-500 hover:bg-green-500/80 text-white'
-					asChild
-				>
-					<Link
-						href={`https://wa.me/?text=${WHATSAPP_TEXT}`}
-						target='_blank'
-					>
-						<WhatsApp className='mr-2 w-5 h-5' /> WhatsApp
-					</Link>
-				</Button>
-				<Button
-					className='bg-blue-500 hover:bg-blue-500/80 text-white'
-					asChild
-				>
-					<Link
-						href={`https://www.linkedin.com/sharing/share-offsite?url=${SHARE_LINK}`}
-						target='_blank'
-					>
-						<LinkedinIcon
-							className='mr-2'
-							fill='#ffffff'
-							size={20}
-							strokeWidth={1}
-						/>{' '}
-						LinkedIn
-					</Link>
-				</Button>
-				<Button className='' asChild>
-					<Link
-						href={`https://twitter.com/intent/tweet?url=${SHARE_LINK}&text=${SHARE_TEXT}`}
-						target='_blank'
-					>
-						<TwitterX className='mr-2' fill='#ffffff' size={20} />{' '}
-						Twitter
-					</Link>
-				</Button>
-				<Button
-					className='bg-red-500 hover:bg-red-500/80 text-white'
-					asChild
-				>
-					<Link
-						href={`https://reddit.com/submit?url=${SHARE_LINK}&title=${SHARE_TEXT}`}
-						target='_blank'
-					>
-						<Reddit className='mr-2' fill='#ffffff' size={20} />{' '}
-						Reddit
-					</Link>
-				</Button>
-				{/* <Button className='bg-blue-500 hover:bg-blue-500/80 text-white' asChild>
+  return (
+    <section className="mt-8 max-w-3xl mx-auto w-full p-4">
+      <h3 className="font-medium">{t("heading")}</h3>
+      <div className="flex items-center gap-2 flex-wrap mt-2">
+        <Button
+          className="bg-green-500 hover:bg-green-500/80 text-white"
+          asChild
+        >
+          <Link href={`https://wa.me/?text=${WHATSAPP_TEXT}`} target="_blank">
+            <WhatsApp className="mr-2 w-5 h-5" /> WhatsApp
+          </Link>
+        </Button>
+        <Button className="bg-blue-500 hover:bg-blue-500/80 text-white" asChild>
+          <Link
+            href={`https://www.linkedin.com/sharing/share-offsite?url=${SHARE_LINK}`}
+            target="_blank"
+          >
+            <LinkedinIcon
+              className="mr-2"
+              fill="#ffffff"
+              size={20}
+              strokeWidth={1}
+            />{" "}
+            LinkedIn
+          </Link>
+        </Button>
+        <Button className="" asChild>
+          <Link
+            href={`https://twitter.com/intent/tweet?url=${SHARE_LINK}&text=${SHARE_TEXT}`}
+            target="_blank"
+          >
+            <TwitterX className="mr-2" fill="#ffffff" size={20} /> Twitter
+          </Link>
+        </Button>
+        <Button className="bg-red-500 hover:bg-red-500/80 text-white" asChild>
+          <Link
+            href={`https://reddit.com/submit?url=${SHARE_LINK}&title=${SHARE_TEXT}`}
+            target="_blank"
+          >
+            <Reddit className="mr-2" fill="#ffffff" size={20} /> Reddit
+          </Link>
+        </Button>
+        {/* <Button className='bg-blue-500 hover:bg-blue-500/80 text-white' asChild>
 					<Link
 						href={`https://www.linkedin.com/shareArticle?${LINKEDIN_TEXT}`}
 						target='_blank'
@@ -105,13 +94,13 @@ const SocialShare: React.FC<SocialShareProps> = ({ post, locale }) => {
 						LinkedIn
 					</Link>
 				</Button> */}
-				<Button className='' onClick={handleCopyLinkToClipboard}>
-					<Copy className='mr-2' strokeWidth={1.5} size={20} />
-					{t('copy')}
-				</Button>
-			</div>
-		</section>
-	);
+        <Button className="" onClick={handleCopyLinkToClipboard}>
+          <Copy className="mr-2" strokeWidth={1.5} size={20} />
+          {t("copy")}
+        </Button>
+      </div>
+    </section>
+  );
 };
 
 export default SocialShare;


### PR DESCRIPTION
This pull request includes changes to various components in the `components/blogs` directory to standardize the code style and improve readability. The most important changes include updating import statements, modifying component props, and adjusting JSX formatting.

### Issues closed

- closes #132 

Code style standardization:

* [`components/blogs/Author.tsx`](diffhunk://#diff-2ff86ce722c732e0a721a3dff2e8839f0712a201fbeaa2514d934ee0e0295793L1-R17): Updated import statements to use double quotes instead of single quotes and adjusted JSX formatting for better readability.
* [`components/blogs/Categories.tsx`](diffhunk://#diff-3bff79a1557e555a6de19a83f59aaebb7e7cc5a26dc3240bf5661e825265197aL1-R32): Updated import statements to use double quotes instead of single quotes and adjusted JSX formatting for better readability.
* [`components/blogs/Content.tsx`](diffhunk://#diff-8e5e1d4266381b3fc274bdd566be8ce1ffbb8b8dc5cd2654dcff532403af760fL1-R15): Updated import statements to use double quotes instead of single quotes and adjusted JSX formatting for better readability.
* [`components/blogs/Header.tsx`](diffhunk://#diff-7a4e43b7d0691cd54ca040893e4947d7c524c9b459269829c9a3935d16348399L1-L37): Updated import statements to use double quotes instead of single quotes and adjusted JSX formatting for better readability.
* [`components/blogs/SocialShare.tsx`](diffhunk://#diff-bd2b714361b8d3d14050b41a82266dbdcc4ca777ef0487f3624ed1e05dcc6137L2-R18): Updated import statements to use double quotes instead of single quotes, adjusted JSX formatting, and modified the `SocialShareProps` type definition. [[1]](diffhunk://#diff-bd2b714361b8d3d14050b41a82266dbdcc4ca777ef0487f3624ed1e05dcc6137L2-R18) [[2]](diffhunk://#diff-bd2b714361b8d3d14050b41a82266dbdcc4ca777ef0487f3624ed1e05dcc6137L30-R86) [[3]](diffhunk://#diff-bd2b714361b8d3d14050b41a82266dbdcc4ca777ef0487f3624ed1e05dcc6137L108-R99)