### PR TITLE
Added Time based revalidation on slug pages (blogs & lab tests)

### DIFF
--- a/app/[locale]/blogs/[slug]/layout.tsx
+++ b/app/[locale]/blogs/[slug]/layout.tsx
@@ -3,62 +3,64 @@
  */
 
 // Dependencies
-import type { Metadata } from 'next';
-import { locales } from '@/i18n/i18n';
-import { sanityFetch } from '@/sanity/lib/sanityFetch';
-import { postQuery } from '@/sanity/lib/queries';
-import { PostQueryResult } from '@/@types/cms';
-import { urlForImage } from '@/sanity/lib/image';
-import { notFound } from 'next/navigation';
+import type { Metadata } from "next";
+import { locales } from "@/i18n/i18n";
+import { sanityFetch } from "@/sanity/lib/sanityFetch";
+import { postQuery } from "@/sanity/lib/queries";
+import { PostQueryResult } from "@/@types/cms";
+import { urlForImage } from "@/sanity/lib/image";
+import { notFound } from "next/navigation";
+
+export const revalidate = 3600;
 
 type IndividualBlogLayoutProps = {
-	params: {
-		locale: LocaleLanguages;
-		slug: string;
-	};
+  params: {
+    locale: LocaleLanguages;
+    slug: string;
+  };
 };
 
 export async function generateMetadata({
-	params: { locale, slug },
+  params: { locale, slug },
 }: IndividualBlogLayoutProps): Promise<Metadata> {
-	const post = await sanityFetch<PostQueryResult>({
-		query: postQuery,
-		params: { slug },
-	});
-	if (!post) {
-		return notFound();
-	}
-	return {
-		title: post?.title?.[locale],
-		description: post?.description?.[locale],
-		openGraph: {
-			...(post?.thumbnail && {
-				images: [
-					{
-						url: urlForImage(post?.thumbnail).format('webp').url(),
-						alt: post?.thumbnail?.alt,
-					},
-				],
-			}),
-		},
-		twitter: {
-			card: 'summary_large_image',
-			...(post?.thumbnail && {
-				images: [
-					{
-						url: urlForImage(post?.thumbnail).format('webp').url(),
-						alt: post?.thumbnail?.alt,
-					},
-				],
-			}),
-		},
-		alternates: {
-			canonical: `/${locale}/blogs/${slug}`,
-			languages: Object.fromEntries(
-				locales.map((locale) => [locale, `/${locale}/blogs/${slug}`])
-			),
-		},
-	};
+  const post = await sanityFetch<PostQueryResult>({
+    query: postQuery,
+    params: { slug },
+  });
+  if (!post) {
+    return notFound();
+  }
+  return {
+    title: post?.title?.[locale],
+    description: post?.description?.[locale],
+    openGraph: {
+      ...(post?.thumbnail && {
+        images: [
+          {
+            url: urlForImage(post?.thumbnail).format("webp").url(),
+            alt: post?.thumbnail?.alt,
+          },
+        ],
+      }),
+    },
+    twitter: {
+      card: "summary_large_image",
+      ...(post?.thumbnail && {
+        images: [
+          {
+            url: urlForImage(post?.thumbnail).format("webp").url(),
+            alt: post?.thumbnail?.alt,
+          },
+        ],
+      }),
+    },
+    alternates: {
+      canonical: `/${locale}/blogs/${slug}`,
+      languages: Object.fromEntries(
+        locales.map((locale) => [locale, `/${locale}/blogs/${slug}`])
+      ),
+    },
+  };
 }
 
 // export async function generateStaticParams() {
@@ -75,9 +77,9 @@ export async function generateMetadata({
 // }
 
 export default function IndividualBlogLayout({
-	children,
+  children,
 }: {
-	children: React.ReactNode;
+  children: React.ReactNode;
 }) {
-	return <>{children}</>;
+  return <>{children}</>;
 }

--- a/app/[locale]/blogs/[slug]/page.tsx
+++ b/app/[locale]/blogs/[slug]/page.tsx
@@ -1,46 +1,48 @@
-import React from 'react';
-import { postQuery } from '@/sanity/lib/queries';
-import { PostQueryResult } from '@/@types/cms';
-import { sanityFetch } from '@/sanity/lib/sanityFetch';
-import { notFound } from 'next/navigation';
-import BlogHeader from '@/components/blogs/Header';
-import BlogAuthor from '@/components/blogs/Author';
-import BlogCategories from '@/components/blogs/Categories';
-import BlogContent from '@/components/blogs/Content';
-import { unstable_setRequestLocale } from 'next-intl/server';
-import CTA from '@/components/cta/CTA';
-import SocialShare from '@/components/blogs/SocialShare';
+import React from "react";
+import { postQuery } from "@/sanity/lib/queries";
+import { PostQueryResult } from "@/@types/cms";
+import { sanityFetch } from "@/sanity/lib/sanityFetch";
+import { notFound } from "next/navigation";
+import BlogHeader from "@/components/blogs/Header";
+import BlogAuthor from "@/components/blogs/Author";
+import BlogCategories from "@/components/blogs/Categories";
+import BlogContent from "@/components/blogs/Content";
+import { unstable_setRequestLocale } from "next-intl/server";
+import CTA from "@/components/cta/CTA";
+import SocialShare from "@/components/blogs/SocialShare";
+
+export const revalidate = 3600;
 
 type IndividualBlogLayoutProps = {
-	params: {
-		locale: LocaleLanguages;
-		slug: string;
-	};
+  params: {
+    locale: LocaleLanguages;
+    slug: string;
+  };
 };
 
 const IndividualBlogPage: React.FC<IndividualBlogLayoutProps> = async ({
-	params: { locale, slug },
+  params: { locale, slug },
 }) => {
-	unstable_setRequestLocale(locale);
-	const post = await sanityFetch<PostQueryResult>({
-		query: postQuery,
-		params: { slug },
-	});
-	if (!post) {
-		return notFound();
-	}
-	return (
-		<article className='w-full'>
-			<BlogHeader post={post} locale={locale} />
-			<BlogContent post={post} locale={locale} />
-			{post.categories && post.categories.length > 0 && (
-				<BlogCategories post={post} locale={locale} />
-			)}
-			{post.author && <BlogAuthor post={post} locale={locale} />}
-			<SocialShare post={post} locale={locale} />
-			<CTA cta={post.cta} />
-		</article>
-	);
+  unstable_setRequestLocale(locale);
+  const post = await sanityFetch<PostQueryResult>({
+    query: postQuery,
+    params: { slug },
+  });
+  if (!post) {
+    return notFound();
+  }
+  return (
+    <article className="w-full">
+      <BlogHeader post={post} locale={locale} />
+      <BlogContent post={post} locale={locale} />
+      {post.categories && post.categories.length > 0 && (
+        <BlogCategories post={post} locale={locale} />
+      )}
+      {post.author && <BlogAuthor post={post} locale={locale} />}
+      <SocialShare post={post} locale={locale} />
+      <CTA cta={post.cta} />
+    </article>
+  );
 };
 
 export default IndividualBlogPage;

--- a/app/[locale]/lab/tests/[slug]/layout.tsx
+++ b/app/[locale]/lab/tests/[slug]/layout.tsx
@@ -3,71 +3,70 @@
  */
 
 // Dependencies
-import type { Metadata } from 'next';
-import { locales } from '@/i18n/i18n';
-import { sanityFetch } from '@/sanity/lib/sanityFetch';
-import { urlForImage } from '@/sanity/lib/image';
-import { notFound } from 'next/navigation';
-import { LabTestQueryResult } from '@/@types/cms';
-import { labTestQuery } from '@/sanity/lib/queries';
+import type { Metadata } from "next";
+import { locales } from "@/i18n/i18n";
+import { sanityFetch } from "@/sanity/lib/sanityFetch";
+import { urlForImage } from "@/sanity/lib/image";
+import { notFound } from "next/navigation";
+import { LabTestQueryResult } from "@/@types/cms";
+import { labTestQuery } from "@/sanity/lib/queries";
+
+export const revalidate = 3600;
 
 type IndividualLabTestLayoutProps = {
-	params: {
-		locale: LocaleLanguages;
-		slug: string;
-	};
+  params: {
+    locale: LocaleLanguages;
+    slug: string;
+  };
 };
 
 export async function generateMetadata({
-	params: { locale, slug },
+  params: { locale, slug },
 }: IndividualLabTestLayoutProps): Promise<Metadata> {
-	const test = await sanityFetch<LabTestQueryResult>({
-		query: labTestQuery,
-		params: { slug },
-	});
-	if (!test) {
-		return notFound();
-	}
-	return {
-		title: test?.name?.[locale],
-		description: test?.description?.[locale],
-		openGraph: {
-			...(test?.thumbnail && {
-				images: [
-					{
-						url: urlForImage(test?.thumbnail).format('webp').url(),
-						alt: test?.thumbnail?.alt,
-					},
-				],
-			}),
-		},
-		twitter: {
-			card: 'summary_large_image',
-			...(test?.thumbnail && {
-				images: [
-					{
-						url: urlForImage(test?.thumbnail).format('webp').url(),
-						alt: test?.thumbnail?.alt,
-					},
-				],
-			}),
-		},
-		alternates: {
-			canonical: `/${locale}/lab/tests/${slug}`,
-			languages: Object.fromEntries(
-				locales.map((locale) => [
-					locale,
-					`/${locale}/lab/tests/${slug}`,
-				])
-			),
-		},
-	};
+  const test = await sanityFetch<LabTestQueryResult>({
+    query: labTestQuery,
+    params: { slug },
+  });
+  if (!test) {
+    return notFound();
+  }
+  return {
+    title: test?.name?.[locale],
+    description: test?.description?.[locale],
+    openGraph: {
+      ...(test?.thumbnail && {
+        images: [
+          {
+            url: urlForImage(test?.thumbnail).format("webp").url(),
+            alt: test?.thumbnail?.alt,
+          },
+        ],
+      }),
+    },
+    twitter: {
+      card: "summary_large_image",
+      ...(test?.thumbnail && {
+        images: [
+          {
+            url: urlForImage(test?.thumbnail).format("webp").url(),
+            alt: test?.thumbnail?.alt,
+          },
+        ],
+      }),
+    },
+    alternates: {
+      canonical: `/${locale}/lab/tests/${slug}`,
+      languages: Object.fromEntries(
+        locales.map((locale) => [locale, `/${locale}/lab/tests/${slug}`])
+      ),
+    },
+  };
 }
 
 export default function IndividualLabTestLayout({
-	children,
+  children,
 }: {
-	children: React.ReactNode;
+  children: React.ReactNode;
 }) {
-	return <>{children}</>;
+  return <>{children}</>;
 }

--- a/app/[locale]/lab/tests/[slug]/page.tsx
+++ b/app/[locale]/lab/tests/[slug]/page.tsx
@@ -1,40 +1,42 @@
-import React from 'react';
-import { sanityFetch } from '@/sanity/lib/sanityFetch';
-import { notFound } from 'next/navigation';
-import { unstable_setRequestLocale } from 'next-intl/server';
-import { LabTestQueryResult } from '@/@types/cms';
-import { labTestQuery } from '@/sanity/lib/queries';
-import LabTestHeader from '@/components/lab/Header';
-import TestInformation from '@/components/lab/TestInformation';
-import TestBody from '@/components/lab/TestBody';
+import React from "react";
+import { sanityFetch } from "@/sanity/lib/sanityFetch";
+import { notFound } from "next/navigation";
+import { unstable_setRequestLocale } from "next-intl/server";
+import { LabTestQueryResult } from "@/@types/cms";
+import { labTestQuery } from "@/sanity/lib/queries";
+import LabTestHeader from "@/components/lab/Header";
+import TestInformation from "@/components/lab/TestInformation";
+import TestBody from "@/components/lab/TestBody";
+
+export const revalidate = 3600;
 
 type IndividualLabTestLayoutProps = {
-	params: {
-		locale: LocaleLanguages;
-		slug: string;
-	};
+  params: {
+    locale: LocaleLanguages;
+    slug: string;
+  };
 };
 
 const IndividualBlogPage: React.FC<IndividualLabTestLayoutProps> = async ({
-	params: { locale, slug },
+  params: { locale, slug },
 }) => {
-	unstable_setRequestLocale(locale);
-	const test = await sanityFetch<LabTestQueryResult>({
-		query: labTestQuery,
-		params: { slug },
-	});
-	if (!test) {
-		return notFound();
-	}
-	return (
-		<main className='w-full'>
-			<LabTestHeader test={test} locale={locale} />
-			<section className='container grid gap-12 lg:grid-cols-3'>
-				<TestBody test={test} locale={locale} />
-				<TestInformation test={test} locale={locale} />
-			</section>
-		</main>
-	);
+  unstable_setRequestLocale(locale);
+  const test = await sanityFetch<LabTestQueryResult>({
+    query: labTestQuery,
+    params: { slug },
+  });
+  if (!test) {
+    return notFound();
+  }
+  return (
+    <main className="w-full">
+      <LabTestHeader test={test} locale={locale} />
+      <section className="container grid gap-12 lg:grid-cols-3">
+        <TestBody test={test} locale={locale} />
+        <TestInformation test={test} locale={locale} />
+      </section>
+    </main>
+  );
 };
 
 export default IndividualBlogPage;


### PR DESCRIPTION
This pull request includes several changes to improve code consistency and add revalidation to specific pages. The most important changes include switching to double quotes for import statements, adding the `revalidate` export, and minor formatting adjustments.

Consistency improvements:

* Changed single quotes to double quotes for import statements across multiple files, including `app/[locale]/blogs/[slug]/layout.tsx`, `app/[locale]/blogs/[slug]/page.tsx`, `app/[locale]/lab/tests/[slug]/layout.tsx`, and `app/[locale]/lab/tests/[slug]/page.tsx`. ([app/[locale]/blogs/[slug]/layout.tsxL6-R14](diffhunk://#diff-a4787745ec8fa69d6c019023b015c35883f53067088e5196306dd55e404fffa8L6-R14), [app/[locale]/blogs/[slug]/page.tsxL1-R14](diffhunk://#diff-d473b18c1f03a32e1089b9db5d055f2aca89c3c958b479af3905fbfab57822fbL1-R14), [app/[locale]/lab/tests/[slug]/layout.tsxL6-R14](diffhunk://#diff-9a3e2af30ccad5ac47c9f8add11194a1da34040074395db8de27ea32dfd72016L6-R14), [app/[locale]/lab/tests/[slug]/page.tsxL1-R11](diffhunk://#diff-b7c51e55d873de6bf7ac4dbc7465de9a87a27c224c723a783667ff92198d40e9L1-R11))

Revalidation addition:

* Added `export const revalidate = 3600;` to `app/[locale]/blogs/[slug]/layout.tsx`, `app/[locale]/blogs/[slug]/page.tsx`, `app/[locale]/lab/tests/[slug]/layout.tsx`, and `app/[locale]/lab/tests/[slug]/page.tsx` to set revalidation to 3600 seconds. ([app/[locale]/blogs/[slug]/layout.tsxL6-R14](diffhunk://#diff-a4787745ec8fa69d6c019023b015c35883f53067088e5196306dd55e404fffa8L6-R14), [app/[locale]/blogs/[slug]/page.tsxL1-R14](diffhunk://#diff-d473b18c1f03a32e1089b9db5d055f2aca89c3c958b479af3905fbfab57822fbL1-R14), [app/[locale]/lab/tests/[slug]/layout.tsxL6-R14](diffhunk://#diff-9a3e2af30ccad5ac47c9f8add11194a1da34040074395db8de27ea32dfd72016L6-R14), [app/[locale]/lab/tests/[slug]/page.tsxL1-R11](diffhunk://#diff-b7c51e55d873de6bf7ac4dbc7465de9a87a27c224c723a783667ff92198d40e9L1-R11))

Formatting adjustments:

* Adjusted indentation and formatting in `generateMetadata` functions and other JSX elements to improve readability and consistency. ([app/[locale]/blogs/[slug]/layout.tsxL38-R51](diffhunk://#diff-a4787745ec8fa69d6c019023b015c35883f53067088e5196306dd55e404fffa8L38-R51), [app/[locale]/blogs/[slug]/page.tsxL33-R35](diffhunk://#diff-d473b18c1f03a32e1089b9db5d055f2aca89c3c958b479af3905fbfab57822fbL33-R35), [app/[locale]/lab/tests/[slug]/layout.tsxL38-R51](diffhunk://#diff-9a3e2af30ccad5ac47c9f8add11194a1da34040074395db8de27ea32dfd72016L38-R51), [app/[locale]/lab/tests/[slug]/layout.tsxL58-R60](diffhunk://#diff-9a3e2af30ccad5ac47c9f8add11194a1da34040074395db8de27ea32dfd72016L58-R60), [app/[locale]/lab/tests/[slug]/page.tsxL30-R34](diffhunk://#diff-b7c51e55d873de6bf7ac4dbc7465de9a87a27c224c723a783667ff92198d40e9L30-R34))