### PR TITLE
UI fixes and team member priority

### DIFF
--- a/app/[locale]/team/page.tsx
+++ b/app/[locale]/team/page.tsx
@@ -3,33 +3,30 @@
  */
 
 // Dependencies
-import TeamMemberCard from '@/components/cards/TeamMember';
-import { teamMembersQuery } from '@/sanity/lib/queries';
-import { sanityFetch } from '@/sanity/lib/sanityFetch';
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
-import { TeamMembersQueryResult } from '@/@types/cms';
+import TeamMemberCard from "@/components/cards/TeamMember";
+import { teamMembersQuery } from "@/sanity/lib/queries";
+import { sanityFetch } from "@/sanity/lib/sanityFetch";
+import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
+import { TeamMembersQueryResult } from "@/@types/cms";
 
 export default async function Team({ params: { locale } }: PageProps) {
-	unstable_setRequestLocale(locale);
-	const teamMembers = await sanityFetch<TeamMembersQueryResult>({
-		query: teamMembersQuery,
-	});
+  unstable_setRequestLocale(locale);
+  const teamMembers = await sanityFetch<TeamMembersQueryResult>({
+    query: teamMembersQuery,
+  });
 
-	const t = await getTranslations('pages.team');
+  const t = await getTranslations("pages.team");
 
-	return (
-		<section className='container'>
-			<h2 className='font-heading font-medium text-lg md:text-2xl max-w-3xl'>
-				{t('heading')}
-			</h2>
-			<div className='mt-8 w-full grid grid-cols-1 md:grid-cols-3 gap-6'>
-				{teamMembers.map((member) => (
-					<TeamMemberCard
-						key={`about-member-${member._id}`}
-						member={member}
-					/>
-				))}
-			</div>
-		</section>
-	);
+  return (
+    <section className="container">
+      <h2 className="font-heading font-medium text-lg md:text-2xl max-w-3xl">
+        {t("heading")}
+      </h2>
+      <div className="mt-8 w-full grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        {teamMembers.map((member) => (
+          <TeamMemberCard key={`about-member-${member._id}`} member={member} />
+        ))}
+      </div>
+    </section>
+  );
 }

--- a/components/about/Team.tsx
+++ b/components/about/Team.tsx
@@ -3,33 +3,30 @@
  */
 
 // Dependencies
-import React from 'react';
-import TeamMemberCard from '../cards/TeamMember';
-import { useTranslations } from 'next-intl';
-import { TeamMembersQueryResult } from '@/@types/cms';
+import React from "react";
+import TeamMemberCard from "../cards/TeamMember";
+import { useTranslations } from "next-intl";
+import { TeamMembersQueryResult } from "@/@types/cms";
 
-type TeamProps = React.ComponentProps<'section'> & {
-	teamMembers: TeamMembersQueryResult;
+type TeamProps = React.ComponentProps<"section"> & {
+  teamMembers: TeamMembersQueryResult;
 };
 
 const Team: React.FC<TeamProps> = ({ teamMembers }) => {
-	const t = useTranslations('pages.about.team');
+  const t = useTranslations("pages.about.team");
 
-	return (
-		<section className='container'>
-			<h2 className='font-heading font-medium text-lg md:text-2xl max-w-3xl'>
-				{t('heading')}
-			</h2>
-			<div className='mt-8 w-full grid grid-cols-1 md:grid-cols-3 gap-6'>
-				{teamMembers.map((member) => (
-					<TeamMemberCard
-						key={`about-member-${member._id}`}
-						member={member}
-					/>
-				))}
-			</div>
-		</section>
-	);
+  return (
+    <section className="container">
+      <h2 className="font-heading font-medium text-lg md:text-2xl max-w-3xl">
+        {t("heading")}
+      </h2>
+      <div className="mt-8 w-full grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        {teamMembers.map((member) => (
+          <TeamMemberCard key={`about-member-${member._id}`} member={member} />
+        ))}
+      </div>
+    </section>
+  );
 };
 
 export default Team;

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -45,7 +45,7 @@ export const galleryImagesQuery = groq`*[_type == "gallery"]{
 
 export const teamMembersQuery = groq`*[_type == "team"]{
   ...
-} | order(_createdAt asc)`;
+} | order(priority asc)`;
 
 export const labTestsQuery = groq`*[_type == "lab-tests" && currentlyAvailable == true]{
   ...

--- a/sanity/schemas/team.ts
+++ b/sanity/schemas/team.ts
@@ -130,6 +130,14 @@ export default defineType({
 			description: 'Languages spoken by the team member.',
 		}),
 		defineField({
+			name: 'priority',
+			title: 'Priority',
+			type: 'number',
+			initialValue: 1,
+			description: 'Display priority (1 = highest priority, 2 = second highest, etc.). Lower numbers appear first.',
+			validation: (Rule) => Rule.required().min(1).integer(),
+		}),
+		defineField({
 			name: 'instagram',
 			title: 'Instagram Profile',
 			type: 'url',


### PR DESCRIPTION
This pull request introduces improvements to how team members are displayed and managed, focusing on enhanced sorting and UI consistency. The most significant change is the addition of a `priority` field to the team member schema, which enables custom ordering of team members. Additionally, there are updates to the grid layout for better responsiveness and code style consistency.

**Team member ordering and schema updates:**

* Added a new `priority` field to the `team` schema (`sanity/schemas/team.ts`). This allows team members to be sorted by display priority, with lower numbers appearing first.
* Updated the `teamMembersQuery` in `sanity/lib/queries.ts` to sort team members by the new `priority` field instead of creation date.

**UI and code style improvements:**

* Updated the grid layout in both `app/[locale]/team/page.tsx` and `components/about/Team.tsx` to add a fourth column on large screens (`lg:grid-cols-4`), improving responsiveness. ([app/[locale]/team/page.tsxL6-R27](diffhunk://#diff-58d6663c54b6e2bb6d77c0e62995df1f083456b6398b0337c4e009dc47f6f486L6-R27), [components/about/Team.tsxL6-R25](diffhunk://#diff-b38aa7b244799a272c15e3c7689da43320dae27828c192a3549b441081a07aa2L6-R25))
* Standardized code formatting across files by switching to double quotes and updating indentation for better readability. ([app/[locale]/team/page.tsxL6-R27](diffhunk://#diff-58d6663c54b6e2bb6d77c0e62995df1f083456b6398b0337c4e009dc47f6f486L6-R27), [components/about/Team.tsxL6-R25](diffhunk://#diff-b38aa7b244799a272c15e3c7689da43320dae27828c192a3549b441081a07aa2L6-R25))