### PR TITLE
Refactor Language Switch Dropdown position

### DIFF
--- a/layouts/Footer.tsx
+++ b/layouts/Footer.tsx
@@ -8,7 +8,6 @@ import Image from 'next/image';
 import { Link } from '@/lib/routing';
 import { Button } from '@/components/ui/button';
 import { Clock } from 'lucide-react';
-import LanguageSwitch from './language-switch';
 import { FOOTER_NAVIGATION } from '@/constants/navigation';
 import { CONTACTS, SOCIALS } from '@/constants/clinic';
 import { useTranslations } from 'next-intl';
@@ -139,7 +138,6 @@ const Footer: React.FC<FooterProps> = ({ locale }) => {
 							</Button>
 						))}
 					</div>
-					<LanguageSwitch locale={locale} />
 				</div>
 				<hr className='border-b my-4 border-b-slate-300 mx-auto' />
 				<p className='text-center'>

--- a/layouts/Navbar.tsx
+++ b/layouts/Navbar.tsx
@@ -128,7 +128,9 @@ const Navbar: React.FC<NavbarProps> = ({ locale }) => {
           </div>
         </div>
         <div className="flex items-center gap-4">
-          <LanguageSwitch locale={locale} triggerClassName="hidden md:flex" />
+          <div className="hidden md:flex">
+            <LanguageSwitch locale={locale} />
+          </div>
           <Button asChild className="hidden md:flex">
             <Link
               href={CONTACTS.googleLocation}

--- a/layouts/Navbar.tsx
+++ b/layouts/Navbar.tsx
@@ -2,177 +2,170 @@
  * Navbar Component
  */
 
-'use client';
+"use client";
 
 // Dependencies
-import React, { useState } from 'react';
-import Image from 'next/image';
-import { Button } from '@/components/ui/button';
-import { Clock, Menu, Phone } from 'lucide-react';
-import { NAVBAR_NAVIGATION } from '@/constants/navigation';
-import { CONTACTS } from '@/constants/clinic';
+import React, { useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Clock, Menu, Phone } from "lucide-react";
+import { NAVBAR_NAVIGATION } from "@/constants/navigation";
+import { CONTACTS } from "@/constants/clinic";
 import {
-	Sheet,
-	SheetContent,
-	SheetDescription,
-	SheetHeader,
-	SheetTitle,
-	SheetTrigger,
-	SheetFooter,
-} from '@/components/ui/sheet';
-import { Link, usePathname } from '@/lib/routing';
-import { useTranslations } from 'next-intl';
-import LanguageSwitch from './language-switch';
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  SheetFooter,
+} from "@/components/ui/sheet";
+import { Link, usePathname } from "@/lib/routing";
+import { useTranslations } from "next-intl";
+import LanguageSwitch from "./language-switch";
 
-interface NavbarProps extends React.ComponentProps<'nav'> {
-	locale: LocaleLanguages;
+interface NavbarProps extends React.ComponentProps<"nav"> {
+  locale: LocaleLanguages;
 }
 
 const Navbar: React.FC<NavbarProps> = ({ locale }) => {
-	const pathname = usePathname();
-	const [sheetOpen, setSheetOpen] = useState(false);
+  const pathname = usePathname();
+  const [sheetOpen, setSheetOpen] = useState(false);
 
-	const t = useTranslations();
+  const t = useTranslations();
 
-	const handleCloseSheet = () => setSheetOpen(false);
+  const handleCloseSheet = () => setSheetOpen(false);
 
-	return (
-		<nav className='w-full'>
-			<section className='container mt-0 flex items-center justify-between flex-col md:flex-row gap-4'>
-				<div className='flex items-center justify-between w-full md:w-fit'>
-					<Link href={'/'} className='block w-28' prefetch={false}>
-						<Image
-							src='/logo/logo-fit.png'
-							alt='Sundar Clinic'
-							width={100}
-							height={100}
-							className='w-full h-auto object-contain'
-							loading='lazy'
-						/>
-					</Link>
-					<Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-						<SheetTrigger asChild className='md:hidden'>
-							<Button
-								variant={'outline'}
-								aria-label={t('sr-menu')}
-							>
-								<Menu />
-								<span className='sr-only'>{t('sr-menu')}</span>
-							</Button>
-						</SheetTrigger>
-						<SheetContent className='flex flex-col h-full md:hidden'>
-							<SheetHeader>
-								<SheetTitle>{t('company.name')}</SheetTitle>
-								<SheetDescription>
-									{t('company.tagline')}
-								</SheetDescription>
-							</SheetHeader>
-							<div>
-								<ul className='flex gap-4 flex-col font-heading'>
-									{NAVBAR_NAVIGATION.map((link) => {
-										const isActive = pathname === link.url;
-										return (
-											<li
-												key={`nav-${link.name[locale]}`}
-												className='font-medium w-fit'
-												onClick={handleCloseSheet}
-											>
-												<Link
-													prefetch={false}
-													href={link.url}
-													target={link.target}
-													className={`${
-														isActive
-															? 'text-primary-clinic'
-															: ''
-													} w-full hover:text-primary-clinic transition-all`}
-												>
-													{link.name[locale]}
-												</Link>
-											</li>
-										);
-									})}
-								</ul>
-								<Button
-									asChild
-									className='mt-4 md:mt-0 w-full'
-									onClick={handleCloseSheet}
-									id='sheet-nav-cta-button'
-								>
-									<Link
-										href={CONTACTS.googleLocation}
-										target='_blank'
-									>
-										{t('layouts.navbar.cta')}
-									</Link>
-								</Button>
-								<div className='mt-4 flex items-center justify-center'>
-									<LanguageSwitch locale={locale} />
-								</div>
-							</div>
-							<SheetFooter className='mt-auto text-xs'>
-								{CONTACTS.address}
-							</SheetFooter>
-						</SheetContent>
-					</Sheet>
-				</div>
-				<div className='flex items-center justify-between w-full md:w-1/2'>
-					<div className='flex items-center justify-center gap-4'>
-						<Clock strokeWidth={1.5} size={20} />
-						<p className='flex flex-col text-sm md:text-base'>
-							<span>{t('company.timings.morning')}</span>
-							<span>{t('company.timings.evening')}</span>
-						</p>
-					</div>
-					<div className='flex items-center justify-center gap-4'>
-						<Phone strokeWidth={1.5} size={20} />
-						<Link
-							href={`tel:${CONTACTS.phone}`}
-							className='text-sm md:text-base underline underline-offset-2 hover:text-primary-clinic transition-all'
-						>
-							{CONTACTS.phone}
-						</Link>
-					</div>
-				</div>
-				<div className='flex items-center gap-4'>
-					<LanguageSwitch locale={locale} />
-					<Button asChild className='hidden md:flex'>
-						<Link
-							href={CONTACTS.googleLocation}
-							target='_blank'
-							id='nav-cta-button'
-						>
-							{t('layouts.navbar.cta')}
-						</Link>
-					</Button>
-				</div>
-			</section>
-			<section className='w-full bg-secondary-clinic/5 px-4 py-2 hidden md:block'>
-				<ul className='container mt-0 p-0 flex gap-8 items-center justify-center font-heading'>
-					{NAVBAR_NAVIGATION.map((link) => {
-						const isActive = pathname === link.url;
-						return (
-							<li
-								key={`nav-${link.name[locale]}`}
-								className='font-medium w-fit'
-							>
-								<Link
-									prefetch={false}
-									href={link.url}
-									target={link.target}
-									className={`${
-										isActive ? 'text-primary-clinic' : ''
-									} hover:text-primary-clinic transition-all`}
-								>
-									{link.name[locale]}
-								</Link>
-							</li>
-						);
-					})}
-				</ul>
-			</section>
-		</nav>
-	);
+  return (
+    <nav className="w-full">
+      <section className="container mt-0 flex items-center justify-between flex-col md:flex-row gap-4">
+        <div className="flex items-center justify-between w-full md:w-fit">
+          <Link href={"/"} className="block w-28" prefetch={false}>
+            <Image
+              src="/logo/logo-fit.png"
+              alt="Sundar Clinic"
+              width={100}
+              height={100}
+              className="w-full h-auto object-contain"
+              loading="lazy"
+            />
+          </Link>
+          <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+            <SheetTrigger asChild className="md:hidden">
+              <Button variant={"outline"} aria-label={t("sr-menu")}>
+                <Menu />
+                <span className="sr-only">{t("sr-menu")}</span>
+              </Button>
+            </SheetTrigger>
+            <SheetContent className="flex flex-col h-full md:hidden">
+              <SheetHeader>
+                <SheetTitle>{t("company.name")}</SheetTitle>
+                <SheetDescription>{t("company.tagline")}</SheetDescription>
+              </SheetHeader>
+              <div>
+                <ul className="flex gap-4 flex-col font-heading">
+                  {NAVBAR_NAVIGATION.map((link) => {
+                    const isActive = pathname === link.url;
+                    return (
+                      <li
+                        key={`nav-${link.name[locale]}`}
+                        className="font-medium w-fit"
+                        onClick={handleCloseSheet}
+                      >
+                        <Link
+                          prefetch={false}
+                          href={link.url}
+                          target={link.target}
+                          className={`${
+                            isActive ? "text-primary-clinic" : ""
+                          } w-full hover:text-primary-clinic transition-all`}
+                        >
+                          {link.name[locale]}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <Button
+                  asChild
+                  className="mt-4 md:mt-0 w-full"
+                  onClick={handleCloseSheet}
+                  id="sheet-nav-cta-button"
+                >
+                  <Link href={CONTACTS.googleLocation} target="_blank">
+                    {t("layouts.navbar.cta")}
+                  </Link>
+                </Button>
+                <div className="mt-4 flex items-center justify-center">
+                  <LanguageSwitch
+                    locale={locale}
+                    triggerClassName="w-full items-center justify-center"
+                  />
+                </div>
+              </div>
+              <SheetFooter className="mt-auto text-xs">
+                {CONTACTS.address}
+              </SheetFooter>
+            </SheetContent>
+          </Sheet>
+        </div>
+        <div className="flex items-center justify-between w-full md:w-1/2">
+          <div className="flex items-center justify-center gap-4">
+            <Clock strokeWidth={1.5} size={20} />
+            <p className="flex flex-col text-sm md:text-base">
+              <span>{t("company.timings.morning")}</span>
+              <span>{t("company.timings.evening")}</span>
+            </p>
+          </div>
+          <div className="flex items-center justify-center gap-4">
+            <Phone strokeWidth={1.5} size={20} />
+            <Link
+              href={`tel:${CONTACTS.phone}`}
+              className="text-sm md:text-base underline underline-offset-2 hover:text-primary-clinic transition-all"
+            >
+              {CONTACTS.phone}
+            </Link>
+          </div>
+        </div>
+        <div className="flex items-center gap-4">
+          <LanguageSwitch locale={locale} triggerClassName="hidden md:flex" />
+          <Button asChild className="hidden md:flex">
+            <Link
+              href={CONTACTS.googleLocation}
+              target="_blank"
+              id="nav-cta-button"
+            >
+              {t("layouts.navbar.cta")}
+            </Link>
+          </Button>
+        </div>
+      </section>
+      <section className="w-full bg-secondary-clinic/5 px-4 py-2 hidden md:block">
+        <ul className="container mt-0 p-0 flex gap-8 items-center justify-center font-heading">
+          {NAVBAR_NAVIGATION.map((link) => {
+            const isActive = pathname === link.url;
+            return (
+              <li
+                key={`nav-${link.name[locale]}`}
+                className="font-medium w-fit"
+              >
+                <Link
+                  prefetch={false}
+                  href={link.url}
+                  target={link.target}
+                  className={`${
+                    isActive ? "text-primary-clinic" : ""
+                  } hover:text-primary-clinic transition-all`}
+                >
+                  {link.name[locale]}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </nav>
+  );
 };
 
 export default Navbar;

--- a/layouts/Navbar.tsx
+++ b/layouts/Navbar.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/sheet';
 import { Link, usePathname } from '@/lib/routing';
 import { useTranslations } from 'next-intl';
+import LanguageSwitch from './language-switch';
 
 interface NavbarProps extends React.ComponentProps<'nav'> {
 	locale: LocaleLanguages;
@@ -105,6 +106,9 @@ const Navbar: React.FC<NavbarProps> = ({ locale }) => {
 										{t('layouts.navbar.cta')}
 									</Link>
 								</Button>
+								<div className='mt-4 flex items-center justify-center'>
+									<LanguageSwitch locale={locale} />
+								</div>
 							</div>
 							<SheetFooter className='mt-auto text-xs'>
 								{CONTACTS.address}
@@ -130,15 +134,18 @@ const Navbar: React.FC<NavbarProps> = ({ locale }) => {
 						</Link>
 					</div>
 				</div>
-				<Button asChild className='hidden md:flex'>
-					<Link
-						href={CONTACTS.googleLocation}
-						target='_blank'
-						id='nav-cta-button'
-					>
-						{t('layouts.navbar.cta')}
-					</Link>
-				</Button>
+				<div className='flex items-center gap-4'>
+					<LanguageSwitch locale={locale} />
+					<Button asChild className='hidden md:flex'>
+						<Link
+							href={CONTACTS.googleLocation}
+							target='_blank'
+							id='nav-cta-button'
+						>
+							{t('layouts.navbar.cta')}
+						</Link>
+					</Button>
+				</div>
 			</section>
 			<section className='w-full bg-secondary-clinic/5 px-4 py-2 hidden md:block'>
 				<ul className='container mt-0 p-0 flex gap-8 items-center justify-center font-heading'>

--- a/layouts/language-switch.tsx
+++ b/layouts/language-switch.tsx
@@ -1,62 +1,71 @@
-'use client';
+"use client";
 
-import React, { useState } from 'react';
+import React from "react";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from '@/components/ui/select';
-import { usePathname, useRouter } from '@/lib/routing';
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { usePathname, useRouter } from "@/lib/routing";
+import { cn } from "@/lib/utils";
 
 interface Props extends React.ComponentProps<typeof Select> {
-	locale: LocaleLanguages;
+  locale: LocaleLanguages;
+  triggerClassName?: string;
 }
 
-const LanguageSwitch: React.FC<Props> = ({ locale }) => {
-	const router = useRouter();
-	const pathname = usePathname();
+const LanguageSwitch: React.FC<Props> = ({
+  locale,
+  triggerClassName,
+  ...props
+}) => {
+  const router = useRouter();
+  const pathname = usePathname();
 
-	const locales: ReadonlyArray<{
-		id: LocaleLanguages;
-		title: string;
-	}> = [
-		{
-			id: 'en',
-			title: 'English',
-		},
-		{
-			id: 'ta',
-			title: 'தமிழ்',
-		},
-		{
-			id: 'hi',
-			title: 'हिंदी',
-		},
-	];
+  const locales: ReadonlyArray<{
+    id: LocaleLanguages;
+    title: string;
+  }> = [
+    {
+      id: "en",
+      title: "English",
+    },
+    {
+      id: "ta",
+      title: "தமிழ்",
+    },
+    {
+      id: "hi",
+      title: "हिंदी",
+    },
+  ];
 
-	const handleChange = (value: LocaleLanguages) => {
-		router.push(pathname, { locale: value, scroll: false });
-	};
+  const handleChange = (value: LocaleLanguages) => {
+    router.push(pathname, { locale: value, scroll: false });
+  };
 
-	return (
-		<Select onValueChange={handleChange} value={locale}>
-			<SelectTrigger
-				aria-label='language switch button'
-				className={`w-fit bg-transparent text-black border-none ring-0`}
-			>
-				<SelectValue />
-			</SelectTrigger>
-			<SelectContent side='bottom'>
-				{locales.map((item) => (
-					<SelectItem key={`local-${item.id}`} value={item.id}>
-						{item.title}
-					</SelectItem>
-				))}
-			</SelectContent>
-		</Select>
-	);
+  return (
+    <Select onValueChange={handleChange} value={locale} {...props}>
+      <SelectTrigger
+        aria-label="language switch button"
+        className={cn(
+          "w-fit bg-transparent text-black border-none ring-0",
+          triggerClassName
+        )}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent side="bottom">
+        {locales.map((item) => (
+          <SelectItem key={`local-${item.id}`} value={item.id}>
+            {item.title}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
 };
 
 export default LanguageSwitch;


### PR DESCRIPTION
This pull request refactors the language switcher component and updates its usage in the navigation and footer layouts. The main change is to allow passing a custom CSS class to the language switch trigger, improving layout flexibility and consistency. The language switcher is now more integrated into the navigation bar and removed from the footer.

**Issues closed:**

- closes #146 

**Component Refactoring and API Improvements:**

* [`layouts/language-switch.tsx`](diffhunk://#diff-f9eb3e13f873eb1238b660be6db2b5dd1b1fa66e01d141893f4d9dd5c3f649f3L1-R23): Refactored `LanguageSwitch` to accept a new optional `triggerClassName` prop for custom styling, replaced manual string concatenation with the `cn` utility, and cleaned up imports and formatting. [[1]](diffhunk://#diff-f9eb3e13f873eb1238b660be6db2b5dd1b1fa66e01d141893f4d9dd5c3f649f3L1-R23) [[2]](diffhunk://#diff-f9eb3e13f873eb1238b660be6db2b5dd1b1fa66e01d141893f4d9dd5c3f649f3L26-R41) [[3]](diffhunk://#diff-f9eb3e13f873eb1238b660be6db2b5dd1b1fa66e01d141893f4d9dd5c3f649f3L44-R60)

**Navigation Layout Updates:**

* [`layouts/Navbar.tsx`](diffhunk://#diff-587a043ce9834fd40bde24e245858ad100da34e739e5d2d72bf81f1c19795215L5-R13): Added the updated `LanguageSwitch` to both mobile and desktop navigation layouts, passing appropriate `triggerClassName` for styling; improved code consistency and formatting throughout the file. [[1]](diffhunk://#diff-587a043ce9834fd40bde24e245858ad100da34e739e5d2d72bf81f1c19795215L5-R13) [[2]](diffhunk://#diff-587a043ce9834fd40bde24e245858ad100da34e739e5d2d72bf81f1c19795215L22-R27) [[3]](diffhunk://#diff-587a043ce9834fd40bde24e245858ad100da34e739e5d2d72bf81f1c19795215L39-R80) [[4]](diffhunk://#diff-587a043ce9834fd40bde24e245858ad100da34e739e5d2d72bf81f1c19795215L97-R157)

**Footer Layout Update:**

* [`layouts/Footer.tsx`](diffhunk://#diff-a59f328bbed640c4da1a146c6d640b33aa5861b7c58284fc7c38181267335dceL11): Removed the `LanguageSwitch` from the footer to centralize language selection in the navigation bar. [[1]](diffhunk://#diff-a59f328bbed640c4da1a146c6d640b33aa5861b7c58284fc7c38181267335dceL11) [[2]](diffhunk://#diff-a59f328bbed640c4da1a146c6d640b33aa5861b7c58284fc7c38181267335dceL142)